### PR TITLE
Use gradle docker image

### DIFF
--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -1,16 +1,14 @@
-FROM openjdk:8-alpine
+{{#image}}
+  FROM {{{.}}}
+{{/image}}
+
+{{^image}}
+  FROM maven:3-jdk-8
+{{/image}}
 
 WORKDIR /usr/src/app
 
 COPY . ./
-
-{{#deps}}
-  RUN apk add {{{.}}}
-{{/deps}}
-
-{{^deps}}
-  RUN apk add maven
-{{/deps}}
 
 {{#build}}
   RUN {{{.}}}

--- a/java/micronaut/config.yaml
+++ b/java/micronaut/config.yaml
@@ -2,10 +2,7 @@ framework:
   website: micronaut.io
   version: 1.2
 
-image: gradle
-
-deps:
-  - gradle
+image: gradle:jdk8
 
 build:
   - gradle build


### PR DESCRIPTION
Hi @gnomeria,

This `PR` fix some issue, detected by CI.

`gradle` is only available on version **4.x** on `alpine`, so I switch to `docker` image for compilation step.

Regards,

-----------
Merging this `PR` will trigger CI, so as I can merge your initial `PR` with confident :heart: 